### PR TITLE
Changed gender of fructus

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -161,7 +161,7 @@ right_rows:
     - title: 4th Declension
       data:
         - color: red 
-          sample_word: frūctus, -ūs, <sm>f.</sm> <i>fruit</i> 
+          sample_word: frūctus, -ūs, <sm>m.</sm> <i>fruit</i> 
           title: singular 
           nom: frūct[us] 
           gen: frūct[ūs] 


### PR DESCRIPTION
Changed 4th declension word fructus's gender from feminine to masculine, per [Wiktionary](https://en.wiktionary.org/wiki/fructus#Noun).
